### PR TITLE
Add user reaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Token
-token.txt
+# Setting
+setting.txt
 # User Data file
 user.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Token
+token.txt
+# User Data file
+user.txt

--- a/main.py
+++ b/main.py
@@ -1,8 +1,11 @@
+from tokenize import Token
 import discord,sys
 
 client = discord.Client()
 # Token file read.
-Token = open('token.txt', 'r').read()
+setting = open('setting.txt', 'r').readlines()
+Token = setting[0]
+bot_owner_id = setting[1]
 Version = "1.0 (Developer Preview)"
 Genkaiya_emoji = "<:genkaiya:1008703726405562474>"
 
@@ -38,8 +41,11 @@ async def on_message(message):
     elif message.content == 'gen!license':
         await message.reply("限界やちゃんは Brain-Hackers により、Creative Commons BY-SA 4.0 でライセンスされています。\nhttps://github.com/brain-hackers/README/blob/main/assets.md")
     elif message.content == 'gen!exit':
-        await message.channel.send("さよならー")
-        sys.exit()
+        if str(message.author.id) == bot_owner_id:
+            await message.reply("さよならー")
+            sys.exit()
+        else:
+            await message.reply("権限がないんや...")
     elif message.content == 'gen!help':
         helpcmd = f"限界やBot コマンドリスト\n`gen!help` 今実行したコマンドや...\n`gen!ping` Pingを測るコマンドや...\n`gen!license` ライセンス情報を表示するや...\n`gen!add [メンション]` 指定されたユーザーの全てのメッセージを限界にするコマンドや... \n\nバージョン情報:{Version}"
         await message.channel.send(helpcmd)

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ async def on_message(message):
         ping = round(raw_ping * 1000)
         await message.reply("Pong!\nBotのPing値は" + str(ping) + "msです。")
     elif message.content == 'gen!license':
-        await message.reply("限界やちゃんは Brain-Hackers により、Creative Commons BY-SA 4.0 でライセンスされています。\nhttps://github.com/brain-hackers/README/blob/main/assets.md")
+        await message.reply("限界やちゃんは `Brain Hackers` により、Creative Commons BY-SA 4.0 でライセンスされています。\nhttps://github.com/brain-hackers/README/blob/main/assets.md")
     elif message.content == 'gen!exit':
         if str(message.author.id) == bot_owner_id:
             await message.reply("さよならー")

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ async def on_message(message):
         await message.channel.send("さよならー")
         sys.exit()
     elif message.content == 'gen!help':
-        helpcmd = f"限界やBot コマンドリスト\ngen!help 今実行したコマンドや...\ngen!ping Pingを測るコマンドや...\ngen!license ライセンス情報を表示するや...\n\nバージョン情報:{Version}"
+        helpcmd = f"限界やBot コマンドリスト\n`gen!help` 今実行したコマンドや...\n`gen!ping` Pingを測るコマンドや...\n`gen!license` ライセンス情報を表示するや...\n`gen!add [メンション]` 指定されたユーザーの全てのメッセージを限界にするコマンドや... \n\nバージョン情報:{Version}"
         await message.channel.send(helpcmd)
     elif message.content[:7] == "gen!add":
         # User add transaction.

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 import discord,sys
 
 client = discord.Client()
-Token = "your token"
+# Token file read.
+Token = open('token.txt', 'r').read()
 Version = "1.0 (Developer Preview)"
 Genkaiya_emoji = "<:genkaiya:1008703726405562474>"
+
 @client.event
 async def on_ready():
     print("起動しました")
@@ -13,8 +15,22 @@ async def on_ready():
 async def on_message(message):
     if message.author.bot:
         return
+    user_data_text = open('user.txt', 'r')
+    user_data = user_data_text.readlines()
+    user_data_text.close()
+    count = 0
+    for raw_data in user_data:
+        server_id = message.guild.id
+        user_id = message.author.id
+        data = raw_data.split(",")
+        if count > 100:
+            break
+        elif server_id == int(data[0]):
+            if user_id == int(data[1]):
+                await message.add_reaction(Genkaiya_emoji)
+        count += 1
     if '限界' in message.content:
-        await message.add_reaction("<:genkaiya:1008703726405562474>")
+        await message.add_reaction(Genkaiya_emoji)
     elif message.content == 'gen!ping':
         raw_ping = client.latency
         ping = round(raw_ping * 1000)
@@ -27,4 +43,18 @@ async def on_message(message):
     elif message.content == 'gen!help':
         helpcmd = f"限界やBot コマンドリスト\ngen!help 今実行したコマンドや...\ngen!ping Pingを測るコマンドや...\ngen!license ライセンス情報を表示するや...\n\nバージョン情報:{Version}"
         await message.channel.send(helpcmd)
+    elif message.content[:7] == "gen!add":
+        # User add transaction.
+        user_data_text_write = open('user.txt', 'a')
+        server_id = message.guild.id
+        message_user_id = message.content.split(" ")
+        if len(message_user_id) == 2:
+            user_id = message_user_id[1][2:-1]
+            user_id_mention = message_user_id[1]
+        else:
+            user_id = message.author.id
+            user_id_mention = "<@"+str(message.author.id)+">"
+        user_data_text_write.write(str(server_id)+","+str(user_id)+"\n")
+        user_data_text_write.close()
+        await message.reply(user_id_mention+"を追加しました。")
 client.run(Token)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-from tokenize import Token
 import discord,sys
 
 client = discord.Client()


### PR DESCRIPTION
## ユーザーを指定してずっと限界にする機能

サーバーとユーザーの両方を照合してリアクションする。
削除機能はおろか重複検出もないゴミ()
`user.txt` に保存している。


## その他変更

- トークンを別ファイル化
- ヘルプの見た目を変更
- 終了処理をオーナーのみに変更
- `Brain-Hackers` を `Brain Hackers` に変更